### PR TITLE
refactor: switch to mounts over volumes

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -66,14 +66,21 @@
         if frigate_docker_container_network | string | length > 0
         else omit
       }}
-    volumes:
-      - /etc/localtime:/etc/localtime:ro
-      - "{{ frigate_docker_data_bind_path }}:/config"
-      - "{{ frigate_docker_storage_volume.name if frigate_docker_storage_use_docker_volume else frigate_docker_storage_bind_path }}:/media/frigate"
+    mounts:
+      - type: bind
+        read_only: true
+        source: /etc/localtime
+        target: /etc/localtime
+      - type: bind
+        read_only: false
+        source: "{{ frigate_docker_data_bind_path }}"
+        target: /config
+      - type: "{{ 'volume' if frigate_docker_storage_use_docker_volume else 'bind' }}"
+        target: /media/frigate
+        source: "{{ frigate_docker_storage_volume.name if frigate_docker_storage_use_docker_volume else frigate_docker_storage_bind_path }}"
       - type: tmpfs
         target: "{{ frigate_docker_tmpfs_volume.target }}"
-        tmpfs:
-          size: "{{ frigate_docker_tmpfs_volume.size }}"
+        tmpfs_size: "{{ frigate_docker_tmpfs_volume.size }}"
     ports: "{{ frigate_docker_ports_configured }}"
     env: "{{ frigate_docker_env_vars }}"
     state: healthy


### PR DESCRIPTION
The mount of the tmpfs 'volume' was persistently failing, resulting in an anonymous volume being created and mounted into the container as: `/{'type': 'tmpfs', 'target': '/tmp/cache', 'tmpfs': {'size': '1000000000'}}`

Switching from `volumes:` to `mounts:` mounts correctly.