### PR TITLE
feat: allow forwarding IPv6 ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,9 +225,12 @@ frigate_docker_ports:
 |--------|-----------|
 | string | `0.0.0.0` |
 
-Default host IP address to use; see
-https://docs.ansible.com/projects/ansible/latest/collections/community/docker/docker_container_module.html#parameter-default_host_ip
-for an explanation of various values for this.
+Default host IP address to use.
+
+For usage information, see the [`default_host_ip` parameter of the `community.docker.docker_container` module](https://docs.ansible.com/projects/ansible/latest/collections/community/docker/docker_container_module.html#parameter-default_host_ip).
+
+> [!NOTE]
+> This is an advanced option and is unlikely to be needed for most users except those using IPv6 or with complex host network configurations.
 
 ### `frigate_docker_container_network`
 

--- a/README.md
+++ b/README.md
@@ -219,6 +219,16 @@ frigate_docker_ports:
     port: 8555
 ```
 
+### `frigate_docker_default_host_ip`
+
+| Type   | Default   |
+|--------|-----------|
+| string | `0.0.0.0` |
+
+Default host IP address to use; see
+https://docs.ansible.com/projects/ansible/latest/collections/community/docker/docker_container_module.html#parameter-default_host_ip
+for an explanation of various values for this.
+
 ### `frigate_docker_container_network`
 
 | Type   | Default   |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -58,6 +58,8 @@ frigate_docker_ports:
     expose: true
     port: 8555
 
+# https://docs.ansible.com/projects/ansible/latest/collections/community/docker/docker_container_module.html#parameter-default_host_ip
+frigate_docker_default_host_ip: "0.0.0.0"
 frigate_docker_container_network: bridge
 
 # Example:

--- a/meta/argument_specs.yml
+++ b/meta/argument_specs.yml
@@ -209,8 +209,7 @@ argument_specs:
         default: 0.0.0.0
         description:
           - Default host IP address to use for the container network.
-          - The default address is 0.0.0.0
-          - See default_host_ip for community.docker.docker_container
+          - See the O(default_host_ip) parameter of M(community.docker.docker_container).
 
       frigate_docker_container_network:
         type: str

--- a/meta/argument_specs.yml
+++ b/meta/argument_specs.yml
@@ -204,6 +204,14 @@ argument_specs:
                 default: 8556
                 description: Frigate WebRTC UDP port.
 
+      frigate_docker_default_host_ip:
+        type: str
+        default: 0.0.0.0
+        description:
+          - Default host IP address to use for the container network.
+          - The default address is 0.0.0.0
+          - See default_host_ip for community.docker.docker_container
+
       frigate_docker_container_network:
         type: str
         default: bridge

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -67,6 +67,7 @@ frigate_docker_container_base:
       else omit
     }}
   mounts: "{{ frigate_docker_container_mounts }}"
+  default_host_ip: "{{ frigate_docker_default_host_ip }}"
   ports: "{{ frigate_docker_ports_configured }}"
   env: "{{ frigate_docker_env_vars }}"
   state: "{{ frigate_docker_state }}"


### PR DESCRIPTION
community.docker.docker_container allows forwarding IPv6 ports when default_host_ip is set to an empty string. This introduces a variable that allows this to be set.

Note that there may be changes in behaviour when using custom networks - the default behaviour is to attempt to auto-detect the behaviour from the bridge network's `com.docker.network.bridge.host_binding_ipv4` option, and falls back to 0.0.0.0. This explicitly defaults to 0.0.0.0 and allows this to be overwritten by the user.